### PR TITLE
 refactor(menu + card): use MenuGridWidget in FavoriteScreen and unif…

### DIFF
--- a/lib/homescreen.dart
+++ b/lib/homescreen.dart
@@ -751,7 +751,7 @@ class HomeScreen extends StatelessWidget {
     return BottomAppBar(
       shape: const CircularNotchedRectangle(),
       notchMargin: 4.0,
-      color: isDark ? Colors.grey[200] : Colors.green[100],
+      color: isDark ? Colors.green[100]?.withOpacity(0.5): Colors.green[100],
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceAround,
         children: [

--- a/lib/model/productcard.dart
+++ b/lib/model/productcard.dart
@@ -1,3 +1,363 @@
+// import 'package:easy_localization/easy_localization.dart';
+// import 'package:flutter/material.dart';
+// import 'package:foodtek/model/product.dart';
+//
+// class ProductCard extends StatelessWidget {
+//   final Product item;
+//   final VoidCallback onFavoriteToggle;
+//   final VoidCallback onOrderNow;
+//
+//   const ProductCard({
+//     super.key,
+//     required this.item,
+//     required this.onFavoriteToggle,
+//     required this.onOrderNow,
+//   });
+//
+//   @override
+//   Widget build(BuildContext context) {
+//
+//     final screenWidth = MediaQuery.of(context).size.width;
+//     final isSmallScreen = screenWidth < 400;
+//
+//     return SizedBox(
+//       //   height: isSmallScreen ? 240 : 270,
+//       height: 252,
+//       width:177,
+//
+//       child: Stack(
+//
+//         clipBehavior: Clip.none,
+//         children: [
+//           // الكارد الأساسي (يبدأ بعد الصورة)
+//           Positioned(
+//             top: isSmallScreen ? 30 : 40,
+//             left: 5,
+//             right: 5,
+//             child: Card(
+//             color: Colors.transparent,
+//               shape: RoundedRectangleBorder(
+//                 borderRadius: BorderRadius.circular(25),
+//                 side: BorderSide(color: Color(0xFFDBF4D1), width: 2),
+//               ),
+//               elevation: 0,
+//               child: Padding(
+//                 padding: EdgeInsets.fromLTRB(15, 50, 15, 20),
+//                 child: Column(
+//                   mainAxisAlignment: MainAxisAlignment.spaceAround,
+//                   crossAxisAlignment: CrossAxisAlignment.center,
+//                   children: [
+//                     Text(
+//                       item.name.tr() ?? "No Name",
+//                       style: TextStyle(
+//                         fontSize: isSmallScreen ? 14 : 16,
+//                         fontWeight: FontWeight.bold,
+//                       ),
+//                       textAlign: TextAlign.center,
+//                       maxLines: 2,
+//                       overflow: TextOverflow.ellipsis,
+//                     ),
+//                     const SizedBox(height: 6),
+//                     Text(
+//                       item.description.tr() ?? "No Description",
+//                       style: TextStyle(
+//                         fontSize: isSmallScreen ? 10 : 12,
+//                         color: Colors.grey[700],
+//                       ),
+//                       maxLines: 2,
+//                       overflow: TextOverflow.ellipsis,
+//                       textAlign: TextAlign.center,
+//                     ),
+//                     const SizedBox(height: 6),
+//                     Text(
+//                       "\$${(item.price ?? 0).toStringAsFixed(2)}",
+//                       style: TextStyle(
+//                         fontSize: isSmallScreen ? 16 : 18,
+//                         color: Colors.black,
+//                         fontWeight: FontWeight.bold,
+//                       ),
+//                     ),
+//                     SizedBox(height: 20,)
+//                   ],
+//
+//                 ),
+//               ),
+//             ),
+//           ),
+//
+//           Positioned(
+//             top: 0,
+//             left: 0,
+//             right: 0,
+//             child: Align(
+//               alignment: Alignment.topCenter,
+//               child: CircleAvatar(
+//                 radius: isSmallScreen ? 30 : 40,
+//                 backgroundColor: Colors.white,
+//                 backgroundImage: item.image != null
+//                     ? AssetImage(item.image!)
+//                     : const AssetImage('assets/images/default.png'),
+//               ),
+//             ),
+//           ),
+//
+//           Positioned(
+//             top: 20,
+//             right: 0, // على الحافة اليمنى
+//             child: IconButton(
+//               style: ButtonStyle(
+//                 backgroundColor: WidgetStatePropertyAll<Color>(
+//                     Color(0xFFDBF4D1)
+//
+//
+//                 ),
+//                 shape:WidgetStatePropertyAll<RoundedRectangleBorder>(
+//               RoundedRectangleBorder(
+//               borderRadius: BorderRadius.circular(15)
+//               ),
+//                 )),
+//               icon: Icon(
+//                 item.isFavorite ? Icons.favorite : Icons.favorite_border,
+//                 color: Colors.green,
+//                 size: isSmallScreen ? 20 : 24,
+//
+//               ),
+//               onPressed: onFavoriteToggle,
+//
+//             ),
+//           ),
+//
+//           // زر الطلب
+//           // Positioned(
+//           //
+//           //   left: 0,
+//           //   right: 0,
+//           //   bottom: 0,
+//           //   child: Padding(
+//           //     padding: const EdgeInsets.symmetric(horizontal: 15),
+//           //     child: SizedBox(
+//           //       width: 105,
+//           //       height: 27,
+//           //       child: ElevatedButton(
+//           //         onPressed: onOrderNow,
+//           //         style: ElevatedButton.styleFrom(
+//           //           backgroundColor: Colors.green,
+//           //           foregroundColor: Colors.white,
+//           //           shape: const StadiumBorder(),
+//           //           padding: EdgeInsets.symmetric(
+//           //             vertical: isSmallScreen ? 8 : 12,
+//           //           ),
+//           //         ),
+//           //
+//           //         child: Text(
+//           //           "Order Now".tr(),
+//           //           style: TextStyle(
+//           //             fontSize: isSmallScreen ? 12 : 14,
+//           //           ),
+//           //         ),
+//           //       ),
+//           //     ),
+//           //   ),
+//           //),
+//           Positioned(
+//             left: 0,
+//             right: 0,
+//             bottom: 35, // مسافة بسيطة من الأسفل
+//             child: Align(
+//               alignment: Alignment.center,
+//               child: SizedBox(
+//                 width: 95,
+//                 height: 27,
+//                 child: ElevatedButton(
+//                   onPressed: onOrderNow,
+//                   style: ElevatedButton.styleFrom(
+//                     backgroundColor: Colors.green,
+//                     foregroundColor: Colors.white,
+//                     shape: RoundedRectangleBorder(
+//                       borderRadius: BorderRadius.circular(25), // مطابق للـ Radius
+//                     ),
+//                     padding: EdgeInsets.zero, // نلغي الـ padding
+//                   ),
+//                   child: Text(
+//                     "Order Now".tr(),
+//                     style: TextStyle(
+//                       fontSize:isSmallScreen ? 12 : 14
+//                     ),
+//                   ),
+//                 ),
+//               ),
+//             ),
+//           ),
+//
+//         ],
+//       ),
+//     );
+//   }
+// }
+//
+// import 'package:easy_localization/easy_localization.dart';
+// import 'package:flutter/material.dart';
+// import 'package:foodtek/model/product.dart';
+//
+// class ProductCard extends StatelessWidget {
+//   final Product item;
+//   final VoidCallback onFavoriteToggle;
+//   final VoidCallback onOrderNow;
+//
+//   const ProductCard({
+//     super.key,
+//     required this.item,
+//     required this.onFavoriteToggle,
+//     required this.onOrderNow,
+//   });
+//
+//   @override
+//   Widget build(BuildContext context) {
+//     final screenWidth = MediaQuery.of(context).size.width;
+//     final isSmallScreen = screenWidth < 400;
+//
+//     return SizedBox(
+//       height: 252,
+//       width: 177,
+//       child: Stack(
+//         clipBehavior: Clip.none,
+//         children: [
+//           // الكارد الأساسي (يبدأ بعد الصورة)
+//           Positioned(
+//             top: isSmallScreen ? 30 : 40,
+//             left: 5,
+//             right: 5,
+//             child: Card(
+//               color: Colors.transparent,
+//               shape: RoundedRectangleBorder(
+//                 borderRadius: BorderRadius.circular(25),
+//                 side: BorderSide(color: Color(0xFFDBF4D1), width: 2),
+//               ),
+//               elevation: 0,
+//               child: Padding(
+//                 padding: EdgeInsets.fromLTRB(15, 50, 15, 20),
+//                 child: Column(
+//                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
+//                   crossAxisAlignment: CrossAxisAlignment.center,
+//                   children: [
+//                     // الاسم والوصف
+//                     Column(
+//                       children: [
+//                         Text(
+//                           item.name.tr() ?? "No Name",
+//                           style: TextStyle(
+//                             fontSize: isSmallScreen ? 14 : 16,
+//                             fontWeight: FontWeight.bold,
+//                           ),
+//                           textAlign: TextAlign.center,
+//                           maxLines: 1,
+//                           overflow: TextOverflow.ellipsis,
+//                         ),
+//                         const SizedBox(height: 10), // تباعد أكبر بين الاسم والوصف
+//                         Text(
+//                           item.description.tr() ?? "No Description",
+//                           style: TextStyle(
+//                             fontSize: isSmallScreen ? 10 : 12,
+//                             color: Colors.grey[700],
+//                           ),
+//                           textAlign: TextAlign.center,
+//                           maxLines: 2,
+//                           overflow: TextOverflow.ellipsis,
+//                         ),
+//                       ],
+//                     ),
+// SizedBox(height: 20,),
+//                     // السعر
+//                     Text(
+//                       "\$${(item.price ?? 0).toStringAsFixed(2)}",
+//                       style: TextStyle(
+//                         fontSize: isSmallScreen ? 16 : 18,
+//                         color: Colors.black,
+//                         fontWeight: FontWeight.bold,
+//                       ),
+//                     ),
+//                   ],
+//                 ),
+//               ),
+//             ),
+//           ),
+//
+//           // صورة المنتج
+//           Positioned(
+//             top: 0,
+//             left: 0,
+//             right: 0,
+//             child: Align(
+//               alignment: Alignment.topCenter,
+//               child: CircleAvatar(
+//                 radius: isSmallScreen ? 30 : 40,
+//                 backgroundColor: Colors.white,
+//                 backgroundImage: item.image != null
+//                     ? AssetImage(item.image!)
+//                     : const AssetImage('assets/images/default.png'),
+//               ),
+//             ),
+//           ),
+//
+//           // زر المفضلة
+//           Positioned(
+//             top: 20,
+//             right: 0,
+//             child: IconButton(
+//               style: ButtonStyle(
+//                 backgroundColor: WidgetStatePropertyAll<Color>(
+//                   Color(0xFFDBF4D1),
+//                 ),
+//                 shape: WidgetStatePropertyAll<RoundedRectangleBorder>(
+//                   RoundedRectangleBorder(
+//                     borderRadius: BorderRadius.circular(15),
+//                   ),
+//                 ),
+//               ),
+//               icon: Icon(
+//                 item.isFavorite ? Icons.favorite : Icons.favorite_border,
+//                 color: Colors.green,
+//                 size: isSmallScreen ? 20 : 24,
+//               ),
+//               onPressed: onFavoriteToggle,
+//             ),
+//           ),
+//
+//           // زر الطلب
+//           Positioned(
+//             left: 0,
+//             right: 0,
+//             bottom: 35,
+//             child: Align(
+//               alignment: Alignment.center,
+//               child: SizedBox(
+//                 width: 95,
+//                 height: 27,
+//                 child: ElevatedButton(
+//                   onPressed: onOrderNow,
+//                   style: ElevatedButton.styleFrom(
+//                     backgroundColor: Colors.green,
+//                     foregroundColor: Colors.white,
+//                     shape: RoundedRectangleBorder(
+//                       borderRadius: BorderRadius.circular(25),
+//                     ),
+//                     padding: EdgeInsets.zero,
+//                   ),
+//                   child: Text(
+//                     "Order Now".tr(),
+//                     style: TextStyle(
+//                       fontSize: isSmallScreen ? 12 : 14,
+//                     ),
+//                   ),
+//                 ),
+//               ),
+//             ),
+//           ),
+//         ],
+//       ),
+//     );
+//   }
+// }
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:foodtek/model/product.dart';
@@ -16,58 +376,72 @@ class ProductCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     final screenWidth = MediaQuery.of(context).size.width;
     final isSmallScreen = screenWidth < 400;
 
     return SizedBox(
-      //   height: isSmallScreen ? 240 : 270,
-      height: 280,
+      height: 252,
+      width: 177,
       child: Stack(
         clipBehavior: Clip.none,
         children: [
-          // الكارد الأساسي (يبدأ بعد الصورة)
+          // الكارد الأساسي
           Positioned(
             top: isSmallScreen ? 30 : 40,
-            left: 0,
-            right: 0,
+            left: 5,
+            right: 5,
             child: Card(
+              color: theme.cardColor,
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(25),
-                side: BorderSide(color: Colors.grey.shade300, width: 1),
+                side: BorderSide(
+                  color: const Color(0xFFDBF4D1),
+                  width: 1,
+                ),
               ),
-              elevation: 3,
+              elevation: 0,
               child: Padding(
-                padding: EdgeInsets.fromLTRB(15, 50, 15, 55),
+                padding: const EdgeInsets.fromLTRB(15, 50, 15, 20),
                 child: Column(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
                   children: [
-                    Text(
-                      item.name.tr() ?? "No Name",
-                      style: TextStyle(
-                        fontSize: isSmallScreen ? 14 : 16,
-                        fontWeight: FontWeight.bold,
-                      ),
-                      textAlign: TextAlign.center,
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
+                    // الاسم والوصف
+                    Column(
+                      children: [
+                        Text(
+                          item.name.tr() ?? "No Name",
+                          style: TextStyle(
+                            fontSize: isSmallScreen ? 14 : 16,
+                            fontWeight: FontWeight.bold,
+                            color: theme.textTheme.bodyLarge?.color,
+                          ),
+                          textAlign: TextAlign.center,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        const SizedBox(height: 10),
+                        Text(
+                          item.description.tr() ?? "No Description",
+                          style: TextStyle(
+                            fontSize: isSmallScreen ? 10 : 12,
+                            color: theme.textTheme.bodyMedium?.color?.withOpacity(0.7),
+                          ),
+                          textAlign: TextAlign.center,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ],
                     ),
-                    const SizedBox(height: 6),
-                    Text(
-                      item.description.tr() ?? "No Description",
-                      style: TextStyle(
-                        fontSize: isSmallScreen ? 10 : 12,
-                        color: Colors.grey[700],
-                      ),
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                      textAlign: TextAlign.center,
-                    ),
-                    const SizedBox(height: 6),
+                    const SizedBox(height: 20),
+                    // السعر
                     Text(
                       "\$${(item.price ?? 0).toStringAsFixed(2)}",
                       style: TextStyle(
                         fontSize: isSmallScreen ? 16 : 18,
-                        color: Colors.black,
                         fontWeight: FontWeight.bold,
+                        color: theme.textTheme.bodyLarge?.color,
                       ),
                     ),
                   ],
@@ -76,6 +450,7 @@ class ProductCard extends StatelessWidget {
             ),
           ),
 
+          // صورة المنتج
           Positioned(
             top: 0,
             left: 0,
@@ -92,10 +467,21 @@ class ProductCard extends StatelessWidget {
             ),
           ),
 
+          // زر المفضلة
           Positioned(
             top: 20,
-            right: 0, // على الحافة اليمنى
+            right: 0,
             child: IconButton(
+              style: ButtonStyle(
+                backgroundColor: const WidgetStatePropertyAll<Color>(
+                  Color(0xFFDBF4D1),
+                ),
+                shape: WidgetStatePropertyAll<RoundedRectangleBorder>(
+                  RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(15),
+                  ),
+                ),
+              ),
               icon: Icon(
                 item.isFavorite ? Icons.favorite : Icons.favorite_border,
                 color: Colors.green,
@@ -109,20 +495,21 @@ class ProductCard extends StatelessWidget {
           Positioned(
             left: 0,
             right: 0,
-            bottom: 0,
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 15),
+            bottom: 35,
+            child: Align(
+              alignment: Alignment.center,
               child: SizedBox(
-                width: 105,
+                width: 95,
+                height: 27,
                 child: ElevatedButton(
                   onPressed: onOrderNow,
                   style: ElevatedButton.styleFrom(
                     backgroundColor: Colors.green,
                     foregroundColor: Colors.white,
-                    shape: const StadiumBorder(),
-                    padding: EdgeInsets.symmetric(
-                      vertical: isSmallScreen ? 8 : 12,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(25),
                     ),
+                    padding: EdgeInsets.zero,
                   ),
                   child: Text(
                     "Order Now".tr(),

--- a/lib/view/screens/burger_screen.dart
+++ b/lib/view/screens/burger_screen.dart
@@ -14,16 +14,92 @@
 //     );
 //   }
 // }
-
-import 'dart:convert';
-import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:foodtek/view/screens/product_details_screen.dart';
-import '../../cubit/favorite_products_cubit.dart';
-import '../../model/product.dart';
-import '../../model/productcard.dart';
-import 'favorite_screen.dart';
+//
+// import 'dart:convert';
+// import 'package:flutter/material.dart';
+// import 'package:flutter/services.dart';
+// import 'package:flutter_bloc/flutter_bloc.dart';
+// import 'package:foodtek/view/screens/product_details_screen.dart';
+// import '../../cubit/favorite_products_cubit.dart';
+// import '../../model/product.dart';
+// import '../../model/productcard.dart';
+// import 'favorite_screen.dart';
+// //
+// // class BurgerScreen extends StatefulWidget {
+// //   @override
+// //   _BurgerScreenState createState() => _BurgerScreenState();
+// // }
+// //
+// // class _BurgerScreenState extends State<BurgerScreen> {
+// //   List<Product> products = [];
+// //   List<Product> favoriteProducts = []; // قائمة لتخزين المنتجات المفضلة
+// //
+// //   @override
+// //   void initState() {
+// //     super.initState();
+// //     loadMenu();
+// //   }
+// //
+// //   Future<void> loadMenu() async {
+// //     final String response = await rootBundle.loadString("assets/menub.json");
+// //     final List<dynamic> data = jsonDecode(response);
+// //     setState(() {
+// //       products = data.map((json) => Product.fromJson(json)).toList();
+// //     });
+// //   }
+// //
+// //   @override
+// //   Widget build(BuildContext context) {
+// //     return Scaffold(
+// //
+// //       body: Padding(
+// //         padding: const EdgeInsets.all(8.0),
+// //         child: products.isEmpty
+// //             ? Center(child: CircularProgressIndicator())
+// //             : GridView.builder(
+// //           gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+// //             crossAxisCount: 2,
+// //             mainAxisSpacing: 10,
+// //             crossAxisSpacing: 5,
+// //             childAspectRatio: 0.7,
+// //           ),
+// //           itemCount: products.length,
+// //           itemBuilder: (context, index) {
+// //             final item = products[index];
+// //             return ProductCard(
+// //               item: item,
+// //               onFavoriteToggle: () {
+// //                 setState(() {
+// //                   item.isFavorite = !item.isFavorite;
+// //                   // إضافة أو إزالة المنتج من المفضلة بناءً على حالته
+// //                   if (item.isFavorite) {
+// //                     favoriteProducts.add(item);
+// //                   } else {
+// //                     favoriteProducts.remove(item);
+// //                   }
+// //                 });
+// //               },
+// //               onOrderNow: () {
+// //                 Navigator.push(
+// //                   context,
+// //                   MaterialPageRoute(
+// //                     builder: (_) => ProductDetailsScreen(product: item),
+// //                   ),
+// //                 );
+// //               },
+// //             );
+// //           },
+// //         ),
+// //       ),
+// //     );
+// //   }
+// // }
+// import 'dart:convert';
+// import 'package:flutter/material.dart';
+// import 'package:flutter/services.dart';
+// import 'package:foodtek/model/product.dart';
+// import 'package:foodtek/view/screens/favorite_screen.dart';
+// import 'package:foodtek/view/screens/product_details_screen.dart';
 //
 // class BurgerScreen extends StatefulWidget {
 //   @override
@@ -32,7 +108,6 @@ import 'favorite_screen.dart';
 //
 // class _BurgerScreenState extends State<BurgerScreen> {
 //   List<Product> products = [];
-//   List<Product> favoriteProducts = []; // قائمة لتخزين المنتجات المفضلة
 //
 //   @override
 //   void initState() {
@@ -50,99 +125,30 @@ import 'favorite_screen.dart';
 //
 //   @override
 //   Widget build(BuildContext context) {
-//     return Scaffold(
+//     final theme = Theme.of(context);
 //
+//     return Scaffold(
+//       backgroundColor: theme.colorScheme.background, // ✅ خلفية ديناميكية
 //       body: Padding(
 //         padding: const EdgeInsets.all(8.0),
 //         child: products.isEmpty
-//             ? Center(child: CircularProgressIndicator())
+//             ? Center(
+//           child: CircularProgressIndicator(
+//             color: theme.primaryColor, // ✅ لون المؤشر من الثيم
+//           ),
+//         )
 //             : GridView.builder(
 //           gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
 //             crossAxisCount: 2,
-//             mainAxisSpacing: 10,
+//             mainAxisSpacing: 35,
 //             crossAxisSpacing: 5,
-//             childAspectRatio: 0.7,
+//             childAspectRatio: 177/190,
 //           ),
 //           itemCount: products.length,
 //           itemBuilder: (context, index) {
 //             final item = products[index];
 //             return ProductCard(
 //               item: item,
-//               onFavoriteToggle: () {
-//                 setState(() {
-//                   item.isFavorite = !item.isFavorite;
-//                   // إضافة أو إزالة المنتج من المفضلة بناءً على حالته
-//                   if (item.isFavorite) {
-//                     favoriteProducts.add(item);
-//                   } else {
-//                     favoriteProducts.remove(item);
-//                   }
-//                 });
-//               },
-//               onOrderNow: () {
-//                 Navigator.push(
-//                   context,
-//                   MaterialPageRoute(
-//                     builder: (_) => ProductDetailsScreen(product: item),
-//                   ),
-//                 );
-//               },
-//             );
-//           },
-//         ),
-//       ),
-//     );
-//   }
-// }
-import 'dart:convert';
-import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-import 'package:foodtek/model/product.dart';
-import 'package:foodtek/view/screens/favorite_screen.dart';
-import 'package:foodtek/view/screens/product_details_screen.dart';
-//
-// class BurgerScreen extends StatefulWidget {
-//   @override
-//   _BurgerScreenState createState() => _BurgerScreenState();
-// }class _BurgerScreenState extends State<BurgerScreen> {
-//   List<Product> products = [];
-//
-//   @override
-//   void initState() {
-//     super.initState();
-//     loadMenu();
-//   }
-//
-//   Future<void> loadMenu() async {
-//     final String response = await rootBundle.loadString("assets/menub.json");
-//     final List<dynamic> data = jsonDecode(response);
-//     setState(() {
-//       products = data.map((json) => Product.fromJson(json)).toList();
-//     });
-//   }
-//
-//   @override
-//   Widget build(BuildContext context) {
-//     return Scaffold(
-//       backgroundColor: Colors.white,
-//       body: Padding(
-//         padding: const EdgeInsets.all(8.0),
-//         child: products.isEmpty
-//             ? Center(child: CircularProgressIndicator())
-//             : GridView.builder(
-//
-//           gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-//             crossAxisCount: 2,
-//             mainAxisSpacing: 5,
-//             crossAxisSpacing: 5,
-//             childAspectRatio: 0.7,
-//           ),
-//           itemCount: products.length,
-//           itemBuilder: (context, index) {
-//             final item = products[index];
-//             return ProductCard(
-//               item: item,
-//
 //               onFavoriteToggle: () {
 //                 if (item.isFavorite) {
 //                   context.read<FavoriteProductsCubit>().removeFromFavorites(item);
@@ -168,6 +174,14 @@ import 'package:foodtek/view/screens/product_details_screen.dart';
 //     );
 //   }
 // }
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:foodtek/model/product.dart';
+import 'package:foodtek/view/screens/product_details_screen.dart';
+import 'package:foodtek/view/screens/widgets/menu_widget.dart';
+import 'package:foodtek/cubit/favorite_products_cubit.dart';
 
 class BurgerScreen extends StatefulWidget {
   @override
@@ -193,51 +207,28 @@ class _BurgerScreenState extends State<BurgerScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-
     return Scaffold(
-      backgroundColor: theme.colorScheme.background, // ✅ خلفية ديناميكية
-      body: Padding(
-        padding: const EdgeInsets.all(8.0),
-        child: products.isEmpty
-            ? Center(
-          child: CircularProgressIndicator(
-            color: theme.primaryColor, // ✅ لون المؤشر من الثيم
-          ),
-        )
-            : GridView.builder(
-          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-            crossAxisCount: 2,
-            mainAxisSpacing: 35,
-            crossAxisSpacing: 5,
-            childAspectRatio: 177/190,
-          ),
-          itemCount: products.length,
-          itemBuilder: (context, index) {
-            final item = products[index];
-            return ProductCard(
-              item: item,
-              onFavoriteToggle: () {
-                if (item.isFavorite) {
-                  context.read<FavoriteProductsCubit>().removeFromFavorites(item);
-                } else {
-                  context.read<FavoriteProductsCubit>().addToFavorites(item);
-                }
-                setState(() {
-                  item.isFavorite = !item.isFavorite;
-                });
-              },
-              onOrderNow: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) => ProductDetailsScreen(product: item),
-                  ),
-                );
-              },
-            );
-          },
-        ),
+      backgroundColor: Theme.of(context).colorScheme.background,
+      body: MenuGridWidget(
+        products: products,
+        onFavoriteToggle: (item) {
+          if (item.isFavorite) {
+            context.read<FavoriteProductsCubit>().removeFromFavorites(item);
+          } else {
+            context.read<FavoriteProductsCubit>().addToFavorites(item);
+          }
+          setState(() {
+            item.isFavorite = !item.isFavorite;
+          });
+        },
+        onOrderNow: (item) {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (_) => ProductDetailsScreen(product: item),
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/view/screens/favorite_screen.dart
+++ b/lib/view/screens/favorite_screen.dart
@@ -1,563 +1,8 @@
-// // import 'package:flutter/cupertino.dart';
-// // import 'package:flutter/material.dart';
-// //
-// // import '../../model/product.dart';
-// // //
-// // // class FavoriteScreen extends StatefulWidget {
-// // //   @override
-// // //   _FavoriteScreenState createState() => _FavoriteScreenState();
-// // // }
-// // //
-// // // class _FavoriteScreenState extends State<FavoriteScreen> {
-// // //   List<Product> favoriteProducts = [];
-// // //
-// // //   @override
-// // //   Widget build(BuildContext context) {
-// // //     return Scaffold(
-// // //       appBar: AppBar(
-// // //         title: Text("Favorite Products"),
-// // //         automaticallyImplyLeading: false,
-// // //
-// // //       ),
-// // //       body: favoriteProducts.isEmpty
-// // //           ? Center(child: Text("No favorite products"))
-// // //           : ListView.builder(
-// // //         itemCount: favoriteProducts.length,
-// // //         itemBuilder: (context, index) {
-// // //           final item = favoriteProducts[index];
-// // //           return ListTile(
-// // //             leading: Image.asset(item.image ?? 'assets/images/default.png'),
-// // //             title: Text(item.name ?? "No Name"),
-// // //             subtitle: Text("\$${(item.price ?? 0).toStringAsFixed(0)}"),
-// // //           );
-// // //         },
-// // //       ),
-// // //     );
-// // //   }
-// // //
-// // //   void addToFavorites(Product product) {
-// // //     setState(() {
-// // //       favoriteProducts.add(product);
-// // //     });
-// // //   }
-// // //
-// // //   void removeFromFavorites(Product product) {
-// // //     setState(() {
-// // //       favoriteProducts.remove(product);
-// // //     });
-// // //   }
-// // // }
-// // //
-// // // class FavoriteScreen extends StatelessWidget {
-// // //   final List<Product> favoriteProducts;
-// // //
-// // //   const FavoriteScreen({required this.favoriteProducts});
-// // //
-// // //   @override
-// // //   Widget build(BuildContext context) {
-// // //     return Scaffold(
-// // //       appBar: AppBar(
-// // //         title: Text("Favorite Products"),
-// // //       ),
-// // //       body: favoriteProducts.isEmpty
-// // //           ? Center(child: Text("No favorite products"))
-// // //           : ListView.builder(
-// // //         itemCount: favoriteProducts.length,
-// // //         itemBuilder: (context, index) {
-// // //           final item = favoriteProducts[index];
-// // //           return ListTile(
-// // //             leading: Image.asset(item.image ?? 'assets/images/default.png'),
-// // //             title: Text(item.name ?? "No Name"),
-// // //             subtitle: Text("\$${(item.price ?? 0).toStringAsFixed(0)}"),
-// // //           );
-// // //         },
-// // //       ),
-// // //     );
-// // //   }
-// // // }
-// // // import 'package:flutter/material.dart';
-// // // import 'package:flutter_bloc/flutter_bloc.dart';
-// // // import 'package:foodtek/model/product.dart';
-// // // import 'package:foodtek/view/screens/product_details_screen.dart';
-// // // import '../../cubit/favorite_products_cubit.dart';
-// // // import '../../model/productcard.dart';
-// // //
-// // // class FavoriteScreen extends StatelessWidget {
-// // //   final List<Product> favoriteProducts;
-// // //
-// // //   FavoriteScreen({required this.favoriteProducts});
-// // //
-// // //   @override
-// // //   Widget build(BuildContext context) {
-// // //     return Scaffold(
-// // //       appBar: AppBar(
-// // //         title: Text("Favorites"),
-// // //       ),
-// // //       body: Padding(
-// // //         padding: const EdgeInsets.all(8.0),
-// // //         child: favoriteProducts.isEmpty
-// // //             ? Center(child: Text("No Favorite Products"))
-// // //             : GridView.builder(
-// // //           gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-// // //             crossAxisCount: 2,
-// // //             mainAxisSpacing: 10,
-// // //             crossAxisSpacing: 5,
-// // //             childAspectRatio: 0.7,
-// // //           ),
-// // //           itemCount: favoriteProducts.length,
-// // //           itemBuilder: (context, index) {
-// // //             final item = favoriteProducts[index];
-// // //             return ProductCard(
-// // //               item: item,
-// // //               onFavoriteToggle: () {
-// // //                 // يمكنك إضافة أو إزالة من المفضلة حسب الحاجة
-// // //                 context.read<FavoriteProductsCubit>().removeFromFavorites(item);
-// // //               },
-// // //               onOrderNow: () {
-// // //                 Navigator.push(
-// // //                   context,
-// // //                   MaterialPageRoute(
-// // //                     builder: (_) => ProductDetailsScreen(product: item),
-// // //                   ),
-// // //                 );
-// // //               },
-// // //             );
-// // //           },
-// // //         ),
-// // //       ),
-// // //     );
-// // //   }
-// // // }
-// //
-// // import 'package:flutter/material.dart';
-// // import 'package:flutter_bloc/flutter_bloc.dart';
-// // import 'package:foodtek/model/product.dart';
-// // import 'package:foodtek/view/screens/product_details_screen.dart';
-// // import '../../cubit/favorite_products_cubit.dart';
-// // import '../../model/productcard.dart';
-// //
-// // class FavoriteScreen extends StatelessWidget {
-// //   final List<Product> favoriteProducts;
-// //
-// //   FavoriteScreen({required this.favoriteProducts});
-// //
-// //   @override
-// //   Widget build(BuildContext context) {
-// //     return Scaffold(
-// //       appBar: AppBar(
-// //         title: Text("Favorites"),
-// //       ),
-// //       body: Padding(
-// //         padding: const EdgeInsets.all(8.0),
-// //         child: favoriteProducts.isEmpty
-// //             ? Center(child: Text("No Favorite Products"))
-// //             : GridView.builder(
-// //           gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-// //             crossAxisCount: 2,
-// //             mainAxisSpacing: 10,
-// //             crossAxisSpacing: 5,
-// //             childAspectRatio: 0.7,
-// //           ),
-// //           itemCount: favoriteProducts.length,
-// //           itemBuilder: (context, index) {
-// //             final item = favoriteProducts[index];
-// //             return ProductCard(
-// //               item: item,
-// //               onFavoriteToggle: () {
-// //                 // عند الضغط على زر إزالة من المفضلة، عرض Dialog لتأكيد العملية
-// //                 showDialog(
-// //                   context: context,
-// //                   builder: (BuildContext context) {
-// //                     return AlertDialog(
-// //                       title: Text("Remove from Favorites"),
-// //                       content: Text("Are you sure you want to remove this product from your favorites?"),
-// //                       actions: <Widget>[
-// //                         // إزالة زر "Cancel"
-// //                         TextButton(
-// //                           child: Container(
-// //                             width: 295, // العرض
-// //                             height: 48, // الارتفاع
-// //                             padding: EdgeInsets.symmetric(vertical: 10, horizontal: 24),
-// //                             decoration: BoxDecoration(
-// //                               color: Colors.green, // اللون
-// //                               borderRadius: BorderRadius.circular(10), // الزوايا
-// //                               border: Border.all(color: Colors.black12, width: 1), // الحدود
-// //                             ),
-// //                             child: Center(
-// //                               child: Text(
-// //                                 "Yes",
-// //                                 style: TextStyle(
-// //                                   color: Colors.white,
-// //                                   fontSize: 16,
-// //                                   fontWeight: FontWeight.bold,
-// //                                 ),
-// //                               ),
-// //                             ),
-// //                           ),
-// //                           onPressed: () {
-// //                             // إزالة المنتج من المفضلة
-// //                             context.read<FavoriteProductsCubit>().removeFromFavorites(item);
-// //                             Navigator.of(context).pop(); // إغلاق الـ Dialog
-// //                           },
-// //                         ),
-// //                       ],
-// //                     );
-// //                   },
-// //                 );
-// //               },
-// //               onOrderNow: () {
-// //                 Navigator.push(
-// //                   context,
-// //                   MaterialPageRoute(
-// //                     builder: (_) => ProductDetailsScreen(product: item),
-// //                   ),
-// //                 );
-// //               },
-// //             );
-// //           },
-// //         ),
-// //       ),
-// //     );
-// //   }
-// // }
-// //
-// // import 'package:flutter/material.dart';
-// // import 'package:flutter_bloc/flutter_bloc.dart';
-// // import 'package:foodtek/model/product.dart';
-// // import 'package:foodtek/view/screens/product_details_screen.dart';
-// // import '../../cubit/favorite_products_cubit.dart';
-// // import '../../model/productcard.dart';
-// //
-// // class FavoriteScreen extends StatelessWidget {
-// //   const FavoriteScreen({Key? key, required List favoriteProducts}) : super(key: key);
-// //
-// //   @override
-// //   Widget build(BuildContext context) {
-// //     return Scaffold(
-// //       appBar: AppBar(
-// //         title: Text("Favorites"),
-// //       ),
-// //       body: BlocBuilder<FavoriteProductsCubit, List<Product>>(
-// //         builder: (context, favoriteProducts) {
-// //           return Padding(
-// //             padding: const EdgeInsets.all(8.0),
-// //             child: favoriteProducts.isEmpty
-// //                 ? Center(child: Text("No Favorite Products"))
-// //                 : GridView.builder(
-// //               gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-// //                 crossAxisCount: 2,
-// //                 mainAxisSpacing: 10,
-// //                 crossAxisSpacing: 5,
-// //                 childAspectRatio: 0.7,
-// //               ),
-// //               itemCount: favoriteProducts.length,
-// //               itemBuilder: (context, index) {
-// //                 final item = favoriteProducts[index];
-// //                 return ProductCard(
-// //                   item: item,
-// //                   onFavoriteToggle: () {
-// //                     // عند الضغط على زر إزالة من المفضلة، عرض Dialog لتأكيد العملية
-// //                     showDialog(
-// //                       context: context,
-// //                       builder: (BuildContext context) {
-// //                         return AlertDialog(
-// //                           title: Text("Remove from Favorites"),
-// //                           content: Text(
-// //                               "Are you sure you want to remove this product from your favorites?"),
-// //                           actions: <Widget>[
-// //                             // إزالة زر "Cancel"
-// //                             TextButton(
-// //                               child: Container(
-// //                                 width: 295, // العرض
-// //                                 height: 48, // الارتفاع
-// //                                 padding: EdgeInsets.symmetric(
-// //                                     vertical: 10, horizontal: 24),
-// //                                 decoration: BoxDecoration(
-// //                                   color: Colors.green, // اللون
-// //                                   borderRadius:
-// //                                   BorderRadius.circular(10), // الزوايا
-// //                                   border: Border.all(
-// //                                       color: Colors.black12, width: 1), // الحدود
-// //                                 ),
-// //                                 child: Center(
-// //                                   child: Text(
-// //                                     "Yes",
-// //                                     style: TextStyle(
-// //                                       color: Colors.white,
-// //                                       fontSize: 16,
-// //                                       fontWeight: FontWeight.bold,
-// //                                     ),
-// //                                   ),
-// //                                 ),
-// //                               ),
-// //                               onPressed: () {
-// //                                 // إزالة المنتج من المفضلة
-// //                                 context
-// //                                     .read<FavoriteProductsCubit>()
-// //                                     .removeFromFavorites(item);
-// //                                 Navigator.of(context).pop(); // إغلاق الـ Dialog
-// //                               },
-// //                             ),
-// //                           ],
-// //                         );
-// //                       },
-// //                     );
-// //                   },
-// //                   onOrderNow: () {
-// //                     Navigator.push(
-// //                       context,
-// //                       MaterialPageRoute(
-// //                         builder: (_) => ProductDetailsScreen(product: item),
-// //                       ),
-// //                     );
-// //                   },
-// //                 );
-// //               },
-// //             ),
-// //           );
-// //         },
-// //       ),
-// //     );
-// //   }
-// // }
-// //
-// // import 'package:flutter/material.dart';
-// // import 'package:flutter_bloc/flutter_bloc.dart';
-// // import 'package:foodtek/model/product.dart';
-// // import 'package:foodtek/view/screens/product_details_screen.dart';
-// // import '../../cubit/favorite_products_cubit.dart';
-// // import '../../model/productcard.dart';
-// // class FavoriteScreen extends StatelessWidget {
-// //   @override
-// //   Widget build(BuildContext context) {
-// //     return Scaffold(
-// //       appBar: AppBar(
-// //         title: Text("Favorites"),
-// //       ),
-// //       body: BlocBuilder<FavoriteProductsCubit, List<Product>>(
-// //         builder: (context, favoriteProducts) {
-// //           return Padding(
-// //             padding: const EdgeInsets.all(8.0),
-// //             child: favoriteProducts.isEmpty
-// //                 ? Center(child: Text("No Favorite Products"))
-// //                 : GridView.builder(
-// //               gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-// //                 crossAxisCount: 2,
-// //                 mainAxisSpacing: 10,
-// //                 crossAxisSpacing: 5,
-// //                 childAspectRatio: 0.7,
-// //               ),
-// //               itemCount: favoriteProducts.length,
-// //               itemBuilder: (context, index) {
-// //                 final item = favoriteProducts[index];
-// //                 return ProductCard(
-// //                   item: item,
-// //                   onFavoriteToggle: () {
-// //                     // عند الضغط على زر إزالة من المفضلة، عرض Dialog لتأكيد العملية
-// //                     showDialog(
-// //                       context: context,
-// //                       builder: (BuildContext context) {
-// //                         return AlertDialog(
-// //                           title: Text("Remove from Favorites"),
-// //                           content: Text("Are you sure you want to remove this product from your favorites?"),
-// //                           actions: <Widget>[
-// //                             TextButton(
-// //                               child: Container(
-// //                                 width: 295,
-// //                                 height: 48,
-// //                                 padding: EdgeInsets.symmetric(vertical: 10, horizontal: 24),
-// //                                 decoration: BoxDecoration(
-// //                                   color: Colors.green,
-// //                                   borderRadius: BorderRadius.circular(10),
-// //                                   border: Border.all(color: Colors.black12, width: 1),
-// //                                 ),
-// //                                 child: Center(
-// //                                   child: Text(
-// //                                     "Yes",
-// //                                     style: TextStyle(
-// //                                       color: Colors.white,
-// //                                       fontSize: 16,
-// //                                       fontWeight: FontWeight.bold,
-// //                                     ),
-// //                                   ),
-// //                                 ),
-// //                               ),
-// //                               onPressed: () {
-// //                                 context.read<FavoriteProductsCubit>().removeFromFavorites(item);
-// //                                 Navigator.of(context).pop(); // إغلاق الـ Dialog
-// //                               },
-// //                             ),
-// //                           ],
-// //                         );
-// //                       },
-// //                     );
-// //                   },
-// //                   onOrderNow: () {
-// //                     Navigator.push(
-// //                       context,
-// //                       MaterialPageRoute(
-// //                         builder: (_) => ProductDetailsScreen(product: item),
-// //                       ),
-// //                     );
-// //                   },
-// //                 );
-// //               },
-// //             ),
-// //           );
-// //         },
-// //       ),
-// //     );
-// //   }
-// // }
-// //
-//
-// import 'package:flutter/material.dart';
-// import 'package:flutter_bloc/flutter_bloc.dart';
-// import 'package:foodtek/view/screens/widgets/notification_icon.dart';
-// import 'package:foodtek/view/screens/widgets/search_widget.dart';
-// import '../../cubit/favorite_products_cubit.dart';
-// import '../../model/product.dart';
-// import '../../model/productcard.dart';
-// import 'product_details_screen.dart';
-//
-// class FavoriteScreen extends StatelessWidget {
-//   const FavoriteScreen({super.key, required List<Product> favoriteProducts});
-//
-//   @override
-//   Widget build(BuildContext context) {
-//     return Scaffold(
-//       backgroundColor: Colors.white,
-//       appBar: AppBar(
-//         backgroundColor: Colors.white,
-//         elevation: 0,
-//         leading: _buildLocationIcon(),
-//         title: _buildLocationTitle(),
-//         actions: [NotificationIcon()],
-//       ),
-//       body: Padding(
-//         padding: const EdgeInsets.only(left: 30, right: 30, top: 22),
-//         child: Column(
-//           crossAxisAlignment: CrossAxisAlignment.start,
-//           children: [
-//             SearchWidget(),
-//             SizedBox(
-//                 height: 30),
-//             Text(
-//               'favorites',
-//             style: TextStyle(
-//               fontSize: 20,
-//               color: Colors.black,
-//               fontWeight: FontWeight.w600,
-//             ),
-//             ),
-//             SizedBox(
-//               height: 6,
-//             ),
-//             Expanded(
-//               child: BlocBuilder<FavoriteProductsCubit, List<Product>>(
-//                 builder: (context, favoriteProducts) {
-//                   print("Rebuilding FavoriteScreen with: $favoriteProducts");
-//
-//                   if (favoriteProducts.isEmpty) {
-//                     return Center(child: Text("No Favorite Products"));
-//                   }
-//
-//                   return GridView.builder(
-//                     itemCount: favoriteProducts.length,
-//                     gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-//                       crossAxisCount: 2,
-//                       mainAxisSpacing: 10,
-//                       crossAxisSpacing: 5,
-//                       childAspectRatio: 0.7,
-//                     ),
-//                     itemBuilder: (context, index) {
-//                       final item = favoriteProducts[index];
-//                       return ProductCard(
-//                         item: item,
-//                         onFavoriteToggle: () {
-//                           showDialog(
-//                             context: context,
-//                             builder: (_) => AlertDialog(
-//                               title: Text("Remove from Favorites"),
-//                               content: Text("Are you sure?"),
-//                               actions: [
-//                                 TextButton(
-//                                   onPressed: () {
-//                                     context.read<FavoriteProductsCubit>().removeFromFavorites(item);
-//                                     Navigator.of(context).pop();
-//                                   },
-//                                   child: Container(
-//                                     width: MediaQuery.of(context).size.width * 0.8,
-//                                     height: 48,
-//                                     padding: EdgeInsets.symmetric(vertical: 10, horizontal: 24),
-//                                     decoration: BoxDecoration(
-//                                       color: Colors.green,
-//
-//                                       borderRadius: BorderRadius.circular(10),
-//                                       border: Border.all(color: Colors.black12, width: 1),
-//                                     ),
-//                                     child: Center(
-//                                       child: Text(
-//                                         "Yes",
-//                                         style: TextStyle(
-//                                           color: Colors.white,
-//                                           fontSize: 16,
-//                                           fontWeight: FontWeight.bold,
-//                                         ),
-//                                       ),
-//                                     ),
-//                                   ),
-//                                 ),
-//                               ],
-//                             ),
-//                           );
-//                         },
-//                         onOrderNow: () {
-//                           Navigator.push(
-//                             context,
-//                             MaterialPageRoute(
-//                               builder: (_) => ProductDetailsScreen(product: item),
-//                             ),
-//                           );
-//                         },
-//                       );
-//                     },
-//                   );
-//                 },
-//               ),
-//             ),
-//           ],
-//         ),
-//       ),
-//     );
-//   }
-// }
-//
-// Widget _buildLocationIcon() {
-//   return Container(
-//     margin: EdgeInsets.only(left: 15, top: 8, bottom: 8),
-//     decoration: BoxDecoration(
-//       borderRadius: BorderRadius.circular(4),
-//       color: Color(0xff4FAF5A).withOpacity(0.1),
-//     ),
-//     child: Icon(Icons.location_on, color: Color(0xff4FAF5A)),
-//   );
-// }
-//
-// Widget _buildLocationTitle() {
-//   return Column(
-//     crossAxisAlignment: CrossAxisAlignment.start,
-//     children: [
-//       Text("Current location", style: TextStyle(fontSize: 12, color: Color(0xff606060))),
-//       SizedBox(height: 4),
-//       Text("Jl. Soekarno Hatta 15A...", style: TextStyle(fontSize: 14, fontWeight: FontWeight.w600)),
-//     ],
-//   );
-// }
 
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:foodtek/view/screens/widgets/menu_widget.dart';
 import 'package:foodtek/view/screens/widgets/notification_icon.dart';
 import 'package:foodtek/view/screens/widgets/search_widget.dart';
 import '../../cubit/favorite_products_cubit.dart';
@@ -587,7 +32,7 @@ class FavoriteScreen extends StatelessWidget {
         actions: [NotificationIcon()],
       ),
       body: Padding(
-        padding: const EdgeInsets.only(left: 30, right: 30, top: 22),
+        padding: const EdgeInsets.all(5.0),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -602,72 +47,67 @@ class FavoriteScreen extends StatelessWidget {
               ),
             ),
             SizedBox(height: 6),
+
             Expanded(
               child: BlocBuilder<FavoriteProductsCubit, List<Product>>(
                 builder: (context, favoriteProducts) {
                   print("Rebuilding FavoriteScreen with: $favoriteProducts");
 
                   if (favoriteProducts.isEmpty) {
-                    return Center(child: Text("No Favorite Products".tr(), style: TextStyle(color: textColor)));
+                    return Center(
+                      child: Text(
+                        "No Favorite Products".tr(),
+                        style: TextStyle(color: textColor),
+                      ),
+                    );
                   }
 
-                  return GridView.builder(
-                    itemCount: favoriteProducts.length,
-                    gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                      crossAxisCount: 2,
-                      mainAxisSpacing: 10,
-                      crossAxisSpacing: 5,
-                      childAspectRatio: 0.7,
-                    ),
-                    itemBuilder: (context, index) {
-                      final item = favoriteProducts[index];
-                      return ProductCard(
-                        item: item,
-                        onFavoriteToggle: () {
-                          showDialog(
-                            context: context,
-                            builder: (_) => AlertDialog(
-                              title: Text("Remove from Favorites".tr(), style: TextStyle(color: textColor)),
-                              content: Text("Are you sure?".tr(), style: TextStyle(color: textColor)),
-                              actions: [
-                                TextButton(
-                                  onPressed: () {
-                                    context.read<FavoriteProductsCubit>().removeFromFavorites(item);
-                                    Navigator.of(context).pop();
-                                  },
-                                  child: Container(
-                                    width: MediaQuery.of(context).size.width * 0.8,
-                                    height: 48,
-                                    padding: EdgeInsets.symmetric(vertical: 10, horizontal: 24),
-                                    decoration: BoxDecoration(
-                                      color: Colors.green,
-                                      borderRadius: BorderRadius.circular(10),
-                                      border: Border.all(color: Colors.black12, width: 1),
-                                    ),
-                                    child: Center(
-                                      child: Text(
-                                        "Yes".tr(),
-                                        style: TextStyle(
-                                          color: Colors.white,
-                                          fontSize: 16,
-                                          fontWeight: FontWeight.bold,
-                                        ),
-                                      ),
+                  // ✅ استخدام MenuGridWidget
+                  return MenuGridWidget(
+                    products: favoriteProducts,
+                    onFavoriteToggle: (item) {
+                      showDialog(
+                        context: context,
+                        builder: (_) => AlertDialog(
+                          title: Text("Remove from Favorites".tr(), style: TextStyle(color: textColor)),
+                          content: Text("Are you sure?".tr(), style: TextStyle(color: textColor)),
+                          actions: [
+                            TextButton(
+                              onPressed: () {
+                                context.read<FavoriteProductsCubit>().removeFromFavorites(item);
+                                Navigator.of(context).pop();
+                              },
+                              child: Container(
+                                width: MediaQuery.of(context).size.width * 0.8,
+                                height: 48,
+                                padding: EdgeInsets.symmetric(vertical: 10, horizontal: 24),
+                                decoration: BoxDecoration(
+                                  color: Colors.green,
+                                  borderRadius: BorderRadius.circular(10),
+                                  border: Border.all(color: Colors.black12, width: 1),
+                                ),
+                                child: Center(
+                                  child: Text(
+                                    "Yes".tr(),
+                                    style: TextStyle(
+                                      color: Colors.white,
+                                      fontSize: 16,
+                                      fontWeight: FontWeight.bold,
                                     ),
                                   ),
                                 ),
-                              ],
+                              ),
                             ),
-                          );
-                        },
-                        onOrderNow: () {
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                              builder: (_) => ProductDetailsScreen(product: item),
-                            ),
-                          );
-                        },
+                          ],
+                        ),
+                      );
+                    },
+                    onOrderNow: (item) {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => ProductDetailsScreen(product: item),
+                        ),
                       );
                     },
                   );

--- a/lib/view/screens/pizza_screen.dart
+++ b/lib/view/screens/pizza_screen.dart
@@ -22,14 +22,100 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:foodtek/model/product.dart';
 import 'package:foodtek/view/screens/favorite_screen.dart';
 import 'package:foodtek/view/screens/product_details_screen.dart';
+import 'package:foodtek/view/screens/widgets/menu_widget.dart';
 
 import '../../cubit/favorite_products_cubit.dart';
 import '../../model/productcard.dart';
+//
+// class PizzaScreen extends StatefulWidget {
+//   @override
+//   _PizzaScreenState createState() => _PizzaScreenState();
+// }class _PizzaScreenState extends State<PizzaScreen> {
+//   List<Product> products = [];
+//
+//   @override
+//   void initState() {
+//     super.initState();
+//     loadMenu();
+//   }
+//
+//   Future<void> loadMenu() async {
+//     final String response = await rootBundle.loadString("assets/pizzas.json");
+//     final List<dynamic> data = jsonDecode(response);
+//     setState(() {
+//       products = data.map((json) => Product.fromJson(json)).toList();
+//     });
+//   }
+//
+//   @override
+//   Widget build(BuildContext context) {
+//     final theme = Theme.of(context);
+//
+//     return Scaffold(
+//       backgroundColor: theme.colorScheme.background,
+//
+//       body: Padding(
+//
+//         padding: const EdgeInsets.all(8.0),
+//         child: products.isEmpty
+//             ? Center(
+//           child: CircularProgressIndicator(
+//             color: theme.primaryColor, // ✅ لون المؤشر من الثيم
+//           ),
+//         )
+//             : GridView.builder(
+//           gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+//             crossAxisCount: 2,
+//             mainAxisSpacing: 0.0,
+//             crossAxisSpacing: 3,
+//             childAspectRatio: 177/250,
+//           ),
+//           itemCount: products.length,
+//           itemBuilder: (context, index) {
+//             final item = products[index];
+//             return ProductCard(
+//               item: item,
+//               onFavoriteToggle: () {
+//                 if (item.isFavorite) {
+//                   context.read<FavoriteProductsCubit>().removeFromFavorites(item);
+//                 } else {
+//                   context.read<FavoriteProductsCubit>().addToFavorites(item);
+//                 }
+//                 setState(() {
+//                   item.isFavorite = !item.isFavorite;
+//                 });
+//               },
+//
+//               onOrderNow: () {
+//                 Navigator.push(
+//                   context,
+//                   MaterialPageRoute(
+//                     builder: (_) => ProductDetailsScreen(product: item),
+//                   ),
+//                 );
+//               },
+//             );
+//           },
+//         ),
+//       ),
+//     );
+//   }
+// }
+// import 'dart:convert';
+// import 'package:flutter/material.dart';
+// import 'package:flutter/services.dart';
+// import 'package:flutter_bloc/flutter_bloc.dart';
+// import 'package:foodtek/model/product.dart';
+// import 'package:foodtek/screens/product_details_screen.dart';
+// import 'package:foodtek/widgets/menu_grid_widget.dart';
+// import 'package:foodtek/cubit/favorite_products_cubit.dart';
 
 class PizzaScreen extends StatefulWidget {
   @override
   _PizzaScreenState createState() => _PizzaScreenState();
-}class _PizzaScreenState extends State<PizzaScreen> {
+}
+
+class _PizzaScreenState extends State<PizzaScreen> {
   List<Product> products = [];
 
   @override
@@ -48,51 +134,28 @@ class PizzaScreen extends StatefulWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-
     return Scaffold(
-      backgroundColor: theme.colorScheme.background, // ✅ خلفية ديناميكية
-      body: Padding(
-        padding: const EdgeInsets.all(8.0),
-        child: products.isEmpty
-            ? Center(
-          child: CircularProgressIndicator(
-            color: theme.primaryColor, // ✅ لون المؤشر من الثيم
-          ),
-        )
-            : GridView.builder(
-          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-            crossAxisCount: 2,
-            mainAxisSpacing: 35,
-            crossAxisSpacing: 5,
-            childAspectRatio: 177/190,
-          ),
-          itemCount: products.length,
-          itemBuilder: (context, index) {
-            final item = products[index];
-            return ProductCard(
-              item: item,
-              onFavoriteToggle: () {
-                if (item.isFavorite) {
-                  context.read<FavoriteProductsCubit>().removeFromFavorites(item);
-                } else {
-                  context.read<FavoriteProductsCubit>().addToFavorites(item);
-                }
-                setState(() {
-                  item.isFavorite = !item.isFavorite;
-                });
-              },
-              onOrderNow: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) => ProductDetailsScreen(product: item),
-                  ),
-                );
-              },
-            );
-          },
-        ),
+      backgroundColor: Theme.of(context).colorScheme.background,
+      body: MenuGridWidget(
+        products: products,
+        onFavoriteToggle: (item) {
+          if (item.isFavorite) {
+            context.read<FavoriteProductsCubit>().removeFromFavorites(item);
+          } else {
+            context.read<FavoriteProductsCubit>().addToFavorites(item);
+          }
+          setState(() {
+            item.isFavorite = !item.isFavorite;
+          });
+        },
+        onOrderNow: (item) {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (_) => ProductDetailsScreen(product: item),
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/view/screens/sandwich_screen.dart
+++ b/lib/view/screens/sandwich_screen.dart
@@ -43,10 +43,269 @@ import 'package:foodtek/view/screens/product_details_screen.dart';
 import '../../cubit/favorite_products_cubit.dart';
 import '../../model/productcard.dart';
 
+// class SandwichScreen extends StatefulWidget {
+//   @override
+//   _SandwichScreenState createState() => _SandwichScreenState();
+// }class _SandwichScreenState extends State<SandwichScreen> {
+//   List<Product> products = [];
+//
+//   @override
+//   void initState() {
+//     super.initState();
+//     loadMenu();
+//   }
+//
+//   Future<void> loadMenu() async {
+//     final String response = await rootBundle.loadString("assets/sandwiches.json");
+//     final List<dynamic> data = jsonDecode(response);
+//     setState(() {
+//       products = data.map((json) => Product.fromJson(json)).toList();
+//     });
+//   }
+//
+//   @override
+//   Widget build(BuildContext context) {
+//     final theme = Theme.of(context);
+//
+//     return Scaffold(
+//       backgroundColor: theme.colorScheme.background, // ✅ خلفية ديناميكية
+//       body: Padding(
+//         padding: const EdgeInsets.all(8.0),
+//         child: products.isEmpty
+//             ? Center(
+//           child: CircularProgressIndicator(
+//             color: theme.primaryColor, // ✅ لون المؤشر من الثيم
+//           ),
+//         )
+//             : GridView.builder(
+//           gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+//             crossAxisCount: 2,
+//             mainAxisSpacing: 35,
+//             crossAxisSpacing: 5,
+//             childAspectRatio: 177/190,
+//           ),
+//           itemCount: products.length,
+//           itemBuilder: (context, index) {
+//             final item = products[index];
+//             return ProductCard(
+//               item: item,
+//               onFavoriteToggle: () {
+//                 if (item.isFavorite) {
+//                   context.read<FavoriteProductsCubit>().removeFromFavorites(item);
+//                 } else {
+//                   context.read<FavoriteProductsCubit>().addToFavorites(item);
+//                 }
+//                 setState(() {
+//                   item.isFavorite = !item.isFavorite;
+//                 });
+//               },
+//               onOrderNow: () {
+//                 Navigator.push(
+//                   context,
+//                   MaterialPageRoute(
+//                     builder: (_) => ProductDetailsScreen(product: item),
+//                   ),
+//                 );
+//               },
+//             );
+//           },
+//         ),
+//       ),
+//     );
+//   }
+// }
+
+// import 'package:flutter/material.dart';
+//
+// class SandwichScreen extends StatelessWidget {
+//
+//
+//   @override
+//   Widget build(BuildContext context) {
+//     return  Scaffold(
+//
+//         body: Center(
+//           child: Text("Burger Content Here"),
+//         ),
+//
+//     );
+//   }
+// }
+//
+// import 'dart:convert';
+// import 'package:flutter/material.dart';
+// import 'package:flutter/services.dart';
+// import 'package:flutter_bloc/flutter_bloc.dart';
+// import 'package:foodtek/view/screens/product_details_screen.dart';
+// import '../../cubit/favorite_products_cubit.dart';
+// import '../../model/product.dart';
+// import '../../model/productcard.dart';
+// import 'favorite_screen.dart';
+// //
+// // class SandwichScreen extends StatefulWidget {
+// //   @override
+// //   _SandwichScreenState createState() => _SandwichScreenState();
+// // }
+// //
+// // class _SandwichScreenState extends State<SandwichScreen> {
+// //   List<Product> products = [];
+// //   List<Product> favoriteProducts = []; // قائمة لتخزين المنتجات المفضلة
+// //
+// //   @override
+// //   void initState() {
+// //     super.initState();
+// //     loadMenu();
+// //   }
+// //
+// //   Future<void> loadMenu() async {
+// //     final String response = await rootBundle.loadString("assets/menub.json");
+// //     final List<dynamic> data = jsonDecode(response);
+// //     setState(() {
+// //       products = data.map((json) => Product.fromJson(json)).toList();
+// //     });
+// //   }
+// //
+// //   @override
+// //   Widget build(BuildContext context) {
+// //     return Scaffold(
+// //
+// //       body: Padding(
+// //         padding: const EdgeInsets.all(8.0),
+// //         child: products.isEmpty
+// //             ? Center(child: CircularProgressIndicator())
+// //             : GridView.builder(
+// //           gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+// //             crossAxisCount: 2,
+// //             mainAxisSpacing: 10,
+// //             crossAxisSpacing: 5,
+// //             childAspectRatio: 0.7,
+// //           ),
+// //           itemCount: products.length,
+// //           itemBuilder: (context, index) {
+// //             final item = products[index];
+// //             return ProductCard(
+// //               item: item,
+// //               onFavoriteToggle: () {
+// //                 setState(() {
+// //                   item.isFavorite = !item.isFavorite;
+// //                   // إضافة أو إزالة المنتج من المفضلة بناءً على حالته
+// //                   if (item.isFavorite) {
+// //                     favoriteProducts.add(item);
+// //                   } else {
+// //                     favoriteProducts.remove(item);
+// //                   }
+// //                 });
+// //               },
+// //               onOrderNow: () {
+// //                 Navigator.push(
+// //                   context,
+// //                   MaterialPageRoute(
+// //                     builder: (_) => ProductDetailsScreen(product: item),
+// //                   ),
+// //                 );
+// //               },
+// //             );
+// //           },
+// //         ),
+// //       ),
+// //     );
+// //   }
+// // }
+// import 'dart:convert';
+// import 'package:flutter/material.dart';
+// import 'package:flutter/services.dart';
+// import 'package:foodtek/model/product.dart';
+// import 'package:foodtek/view/screens/favorite_screen.dart';
+// import 'package:foodtek/view/screens/product_details_screen.dart';
+//
+// class SandwichScreen extends StatefulWidget {
+//   @override
+//   _SandwichScreenState createState() => _SandwichScreenState();
+// }
+//
+// class _SandwichScreenState extends State<SandwichScreen> {
+//   List<Product> products = [];
+//
+//   @override
+//   void initState() {
+//     super.initState();
+//     loadMenu();
+//   }
+//
+//   Future<void> loadMenu() async {
+//     final String response = await rootBundle.loadString("assets/menub.json");
+//     final List<dynamic> data = jsonDecode(response);
+//     setState(() {
+//       products = data.map((json) => Product.fromJson(json)).toList();
+//     });
+//   }
+//
+//   @override
+//   Widget build(BuildContext context) {
+//     final theme = Theme.of(context);
+//
+//     return Scaffold(
+//       backgroundColor: theme.colorScheme.background, // ✅ خلفية ديناميكية
+//       body: Padding(
+//         padding: const EdgeInsets.all(8.0),
+//         child: products.isEmpty
+//             ? Center(
+//           child: CircularProgressIndicator(
+//             color: theme.primaryColor, // ✅ لون المؤشر من الثيم
+//           ),
+//         )
+//             : GridView.builder(
+//           gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+//             crossAxisCount: 2,
+//             mainAxisSpacing: 35,
+//             crossAxisSpacing: 5,
+//             childAspectRatio: 177/190,
+//           ),
+//           itemCount: products.length,
+//           itemBuilder: (context, index) {
+//             final item = products[index];
+//             return ProductCard(
+//               item: item,
+//               onFavoriteToggle: () {
+//                 if (item.isFavorite) {
+//                   context.read<FavoriteProductsCubit>().removeFromFavorites(item);
+//                 } else {
+//                   context.read<FavoriteProductsCubit>().addToFavorites(item);
+//                 }
+//                 setState(() {
+//                   item.isFavorite = !item.isFavorite;
+//                 });
+//               },
+//               onOrderNow: () {
+//                 Navigator.push(
+//                   context,
+//                   MaterialPageRoute(
+//                     builder: (_) => ProductDetailsScreen(product: item),
+//                   ),
+//                 );
+//               },
+//             );
+//           },
+//         ),
+//       ),
+//     );
+//   }
+// }
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:foodtek/model/product.dart';
+import 'package:foodtek/view/screens/product_details_screen.dart';
+import 'package:foodtek/view/screens/widgets/menu_widget.dart';
+import 'package:foodtek/cubit/favorite_products_cubit.dart';
+
 class SandwichScreen extends StatefulWidget {
   @override
   _SandwichScreenState createState() => _SandwichScreenState();
-}class _SandwichScreenState extends State<SandwichScreen> {
+}
+
+class _SandwichScreenState extends State<SandwichScreen> {
   List<Product> products = [];
 
   @override
@@ -65,51 +324,30 @@ class SandwichScreen extends StatefulWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-
     return Scaffold(
-      backgroundColor: theme.colorScheme.background, // ✅ خلفية ديناميكية
-      body: Padding(
-        padding: const EdgeInsets.all(8.0),
-        child: products.isEmpty
-            ? Center(
-          child: CircularProgressIndicator(
-            color: theme.primaryColor, // ✅ لون المؤشر من الثيم
-          ),
-        )
-            : GridView.builder(
-          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-            crossAxisCount: 2,
-            mainAxisSpacing: 35,
-            crossAxisSpacing: 5,
-            childAspectRatio: 177/190,
-          ),
-          itemCount: products.length,
-          itemBuilder: (context, index) {
-            final item = products[index];
-            return ProductCard(
-              item: item,
-              onFavoriteToggle: () {
-                if (item.isFavorite) {
-                  context.read<FavoriteProductsCubit>().removeFromFavorites(item);
-                } else {
-                  context.read<FavoriteProductsCubit>().addToFavorites(item);
-                }
-                setState(() {
-                  item.isFavorite = !item.isFavorite;
-                });
-              },
-              onOrderNow: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) => ProductDetailsScreen(product: item),
-                  ),
-                );
-              },
-            );
-          },
-        ),
+      backgroundColor: Theme.of(context).colorScheme.background,
+      body: MenuGridWidget(
+
+        products: products,
+
+        onFavoriteToggle: (item) {
+          if (item.isFavorite) {
+            context.read<FavoriteProductsCubit>().removeFromFavorites(item);
+          } else {
+            context.read<FavoriteProductsCubit>().addToFavorites(item);
+          }
+          setState(() {
+            item.isFavorite = !item.isFavorite;
+          });
+        },
+        onOrderNow: (item) {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (_) => ProductDetailsScreen(product: item),
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/view/screens/widgets/menu_widget.dart
+++ b/lib/view/screens/widgets/menu_widget.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:foodtek/model/product.dart';
+import '../../../model/productcard.dart';
+
+class MenuGridWidget extends StatelessWidget {
+  final List<Product> products;
+  final Function(Product) onFavoriteToggle;
+  final Function(Product) onOrderNow;
+
+  const MenuGridWidget({
+    super.key,
+    required this.products,
+    required this.onFavoriteToggle,
+    required this.onOrderNow,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: products.isEmpty
+          ? Center(
+        child: CircularProgressIndicator(
+          color: theme.primaryColor,
+        ),
+      )
+          : GridView.builder(
+        gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: 2,
+          mainAxisSpacing: 0.0,
+          crossAxisSpacing: 3,
+          childAspectRatio: 177 / 250,
+        ),
+        itemCount: products.length,
+        itemBuilder: (context, index) {
+          final item = products[index];
+          return ProductCard(
+            item: item,
+            onFavoriteToggle: () => onFavoriteToggle(item),
+            onOrderNow: () => onOrderNow(item),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.11.0"
   bloc:
     dependency: "direct main"
     description:
@@ -29,34 +29,34 @@ packages:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.1"
+    version: "1.19.0"
   crypto:
     dependency: transitive
     description:
@@ -133,10 +133,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.1"
   ffi:
     dependency: transitive
     description:
@@ -449,18 +449,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.7"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.8"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -497,10 +497,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
@@ -513,10 +513,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.15.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -537,10 +537,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.9.0"
   path_provider_linux:
     dependency: transitive
     description:
@@ -742,10 +742,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.1"
+    version: "1.10.0"
   sprintf:
     dependency: transitive
     description:
@@ -758,18 +758,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.1"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.2"
   stream_transform:
     dependency: transitive
     description:
@@ -782,26 +782,26 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.3.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.3"
   typed_data:
     dependency: transitive
     description:
@@ -902,10 +902,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "14.3.0"
   web:
     dependency: transitive
     description:
@@ -931,5 +931,5 @@ packages:
     source: hosted
     version: "1.1.0"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
+  dart: ">=3.6.1 <4.0.0"
   flutter: ">=3.27.0"


### PR DESCRIPTION
refactor(menu + card): use MenuGridWidget in FavoriteScreen and unify card layout

- Replaced custom GridView in FavoriteScreen with reusable MenuGridWidget
- Improved visual consistency of product cards across all screens
- Ensured card layout uses same GridDelegate and styling in both Menu and Favorites
- Simplified FavoriteScreen logic by delegating grid rendering to MenuGridWidget